### PR TITLE
fix: don't allow Decr to reduce the counter if it's already done

### DIFF
--- a/limit.go
+++ b/limit.go
@@ -192,7 +192,9 @@ func (l *Limiter) IncN(ctx context.Context, key string, limit *Limit, n int) (*R
 
 	res.Allowed = success > 0
 	res.Remaining = maxZero(limit.InFlight - cur)
-	res.n = n
+	if res.Allowed {
+		res.n = n
+	}
 
 	// Let Flusher repair any keys with negative count (incorrect state)
 	if res.Allowed && raw < 1 && l.flusherEnabled() {


### PR DESCRIPTION
If the library is used, without the user actually reacting on Result.Allowed != true we should not Decr the counter on Decr()
